### PR TITLE
F Fly

### DIFF
--- a/src/main/java/com/massivecraft/factions/cmd/CmdFly.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdFly.java
@@ -15,10 +15,11 @@ import java.util.UUID;
 public class CmdFly extends FCommand {
 
     public static final boolean fly = FactionsPlugin.getInstance().getConfig().getBoolean("enable-faction-flight");
+    private static final boolean flyNeedsUpgrade = FactionsPlugin.getInstance().getConfig().getBoolean("ffly.need-faction-upgrade");
     public static List<UUID> falseList = new ArrayList<>();
 
     /**
-     * @author FactionsUUID Team - Modified By CmdrKittens
+     * @author FactionsUUID Team - Modified By CmdrKittens and vSKAH
      */
 
 
@@ -56,6 +57,12 @@ public class CmdFly extends FCommand {
             falseList.add(context.fPlayer.getPlayer().getUniqueId());
             return;
         }
+
+        if (flyNeedsUpgrade && context.faction.getUpgrade("Fly") == 0 && !context.fPlayer.isAdminBypassing()) {
+            context.msg(TL.COMMAND_FLY_NEED_UPGRADE);
+            return;
+        }
+
         // Do checks if true
         if (!flyTest(context, notify)) {
             return;

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -455,6 +455,7 @@ public enum TL {
     COMMAND_DISBAND_CONFIRM("&c&l[!]&7 Your Faction has&c {tnt} &7tnt left in the bank, it will be &clost&7 if the faction is &cdisbanded&7. Type&c /f disband &7again within &c10&7 seconds to&c disband&7."),
     COMMAND_DISBAND_DESCRIPTION("Disband a faction"),
 
+    COMMAND_FLY_NEED_UPGRADE("&c&l[!]&7 You need to upgrade your faction to use this feature."),
     COMMAND_FLY_DISABLED("&c&l[!]&7 Sorry, Faction flight is &cdisabled &7on this server."),
     COMMAND_FLY_DESCRIPTION("Enter or leave Faction flight mode"),
     COMMAND_FLY_CHANGE("&c&l[!]&7 Faction flight has been &c%1$s&7."),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -70,6 +70,7 @@ ffly:
   disable-flight-on-generic-damage: false #Any Damage a Player Takes Their Flight Will Be Disabled
   disable-flight-on-mob-damage: false #Any Damage a Player Takes From A Mob Their Flight Will Be Disabled
   disable-flight-on-player-damage: true
+  need-faction-upgrade: true #If you want to require a faction upgrade to use fly
 
 # If a player leaves fly (out of territory or took damage)
 # how long should they not take fall damage for?

--- a/src/main/resources/configuration/upgrades.yml
+++ b/src/main/resources/configuration/upgrades.yml
@@ -24,6 +24,7 @@ fupgrades:
     - "Chest"
     - "Members"
     - "Armor"
+    - "Fly"
   MainMenu:
     Rows: 5
     Title: '&8&l{faction}''s Upgrade Menu'
@@ -199,6 +200,21 @@ fupgrades:
           - ''
           - '&7&o(( Tip: &f&oleft-click&7&o to &c&oupgrade&7&o ))'
         Slot: 23
+    Fly: #When your faction has this upgrade members don't need permission factions.fly to fly in their claims
+      Max-Level: 1
+      Cost:
+        level-1: 1000000
+      DisplayItem:
+        Name: '&c&lF Fly'
+        Type: FEATHER #MUST BE PLAYER_HEAD FOR TEXTURE TO WORK!
+        Texture: '' #Hash of skull here from minecraft-heads.com
+        Lore:
+          - '&7&oAllows &e&ofly&7&o in &c&oclaims&7&o.'
+          - ''
+          - '&4&l* &cCost: &f$1,000,000'
+          - ''
+          - '&7&o(( Tip: &f&oleft-click&7&o to &c&oupgrade&7&o ))'
+        Slot: 25
     Spawners:
       Max-Level: 3
       Spawner-Boost:


### PR DESCRIPTION
feat(f fly): Change in the fly faction system, it's now possible to make players use the f fly only if they had unlocked an upgrade named Fly.